### PR TITLE
feat(login) : add oauth2.0 page and test

### DIFF
--- a/lib/constants/urls.dart
+++ b/lib/constants/urls.dart
@@ -1,6 +1,7 @@
 class Url {
   Url._();
-  static const String kakaoOAuthUrl = 'https://naver.com';
-  static const String naverOAuthUrl = 'https://naver.com';
-  static const String googleOAuthUrl = 'https://naver.com';
+  static const String loginOAuthUrl = 'http://localhost:8080/api/v1/login';
+  static const String kakaoOAuthUrl = loginOAuthUrl + '/kakao';
+  static const String naverOAuthUrl = loginOAuthUrl + '/naver';
+  static const String googleOAuthUrl = loginOAuthUrl + '/google';
 }

--- a/lib/screens/account_page/account_page.dart
+++ b/lib/screens/account_page/account_page.dart
@@ -1,3 +1,6 @@
+import 'dart:html' as html;
+import 'package:http/http.dart' as http;
+
 import 'package:flutter/material.dart';
 import 'package:beaten_beat/constants/urls.dart';
 import 'package:beaten_beat/constants/color_palette.dart';
@@ -7,11 +10,19 @@ import 'package:auto_size_text/auto_size_text.dart';
 class AccountPage extends StatelessWidget {
   const AccountPage({Key? key}) : super(key: key);
 
-  void _launchURL(String url) async {
-    if (!await canLaunch(url)) {
-      throw 'Could not launch $url';
-    } else {
-      await launch(url);
+  Future<void> loginRedirect(String url) async {
+    try {
+      final response = await http.get(Uri.parse(url));
+      final redirectUrl = response.body;
+
+      if (await canLaunch(redirectUrl)) {
+        await launch(redirectUrl);
+      } else {
+        throw 'Could not launch $redirectUrl';
+      }
+    } catch (e) {
+      // Handle error
+      print('Failed to call API: $e');
     }
   }
 
@@ -65,7 +76,7 @@ class AccountPage extends StatelessWidget {
                     width: MediaQuery.of(context).size.width * 0.3,
                     child: ElevatedButton.icon(
                       onPressed: () {
-                        _launchURL(Url.kakaoOAuthUrl);
+                        html.window.open(Url.kakaoOAuthUrl, '_self');
                       },
                       icon: Image.asset(
                         'assets/logos/kakao.png',
@@ -93,7 +104,7 @@ class AccountPage extends StatelessWidget {
                     width: MediaQuery.of(context).size.width * 0.3,
                     child: ElevatedButton.icon(
                       onPressed: () {
-                        _launchURL(Url.naverOAuthUrl);
+                        html.window.open(Url.naverOAuthUrl, '_self');
                       },
                       icon: Image.asset(
                         'assets/logos/naver.png',
@@ -121,7 +132,7 @@ class AccountPage extends StatelessWidget {
                     width: MediaQuery.of(context).size.width * 0.3,
                     child: ElevatedButton.icon(
                       onPressed: () {
-                        _launchURL(Url.googleOAuthUrl);
+                        loginRedirect(Url.googleOAuthUrl);
                       },
                       icon: Image.asset(
                         'assets/logos/google.png',

--- a/lib/screens/channel_page/channel_page.dart
+++ b/lib/screens/channel_page/channel_page.dart
@@ -1,13 +1,19 @@
+import 'package:http/http.dart' as http;
+
 import 'package:flutter/material.dart';
 
 import 'package:beaten_beat/constants/color_palette.dart';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 
 class ChannelPage extends StatelessWidget {
   const ChannelPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       backgroundColor: ColorPalette.navy,
       body: Column(
         children: [
@@ -20,9 +26,42 @@ class ChannelPage extends StatelessWidget {
               fontWeight: FontWeight.bold,
               color: ColorPalette.sky,
             ),
-          ))
+          )),
+          Center(
+            child: ElevatedButton(
+              onPressed: () {
+                fetchData();
+              },
+              child: Text("Call!"),
+            ),
+          )
         ],
       ),
     );
+  }
+
+  void fetchData() async {
+    try {
+      final Dio dio = Dio();
+      dio.options.extra['withCredentials'] = true;
+
+      // 주어진 URL
+      var url = Uri.parse('http://localhost:8080/api/v1/user/me');
+
+      // GET 요청 보내기
+      var response = await dio.get(url.toString());
+
+      // 응답 처리
+      if (response.statusCode == 200) {
+        // 요청 성공
+        print('Response data: ${response.data}');
+      } else {
+        // 요청 실패
+        print('Request failed with status: ${response.statusCode}');
+      }
+    } catch (e) {
+      // 예외 처리
+      print('Error occurred: $e');
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   youtube_player_iframe: ^4.0.4
   flutter_shake_animated: ^0.0.5
   url_launcher: ^6.2.2
+  http: ^1.2.0
+  flutter_web_auth_2: ^3.1.1
+  dio_cookie_manager: ^3.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Naver, google, Kakako의 Oauth2를 local-host 상에서
테스트 하는 코드를 추가 하였습니다.

account_page에서 로그인이 가능하며,
channel_page에서 request 테스트를 콘솔로 확인가능

ref: #2

## Motivation 🤔
- example

## Key Changes 🔑
- example

## To Reviewers 🙏
- example
