### PR TITLE
refactor(profile_page): add api and change to Stateful

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   dio_cookie_manager: ^3.1.1
   flutter_provider: ^2.1.0
   image_network: ^2.5.6
+  image_picker_web: ^3.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

## Motivation 🤔
- 로그인 기능과, 간단한 회원조회 화면이 필요하다.

## Key Changes 🔑
- OAuth 기능 추가.
-  Api를 통한 내 정보 확인 기능.
-  Api를 통한 내 정보 수정 기능

## To Reviewers 🙏
- example


![스크린샷 2024-02-13 203001](https://github.com/Daki404/BeatenBeat_flutter/assets/67456502/01b0e9d8-4b06-427d-9e11-74fde8e12bf1)

![스크린샷 2024-02-16 183114](https://github.com/Daki404/BeatenBeat_flutter/assets/67456502/710576b1-445a-469a-b256-fc2f7c0a1a42)

![스크린샷 2024-02-16 183129](https://github.com/Daki404/BeatenBeat_flutter/assets/67456502/ca2d90e3-e432-4208-8a0e-f555798f1657)

![스크린샷 2024-02-16 183136](https://github.com/Daki404/BeatenBeat_flutter/assets/67456502/e7825714-204f-4c67-a368-9926300a5eea)
